### PR TITLE
Fix JSON entry type parsing, Write sector-aligned section lengths 

### DIFF
--- a/psxfudge/cli/bundle.py
+++ b/psxfudge/cli/bundle.py
@@ -38,7 +38,13 @@ class _FudgeBundle(MultiEntryTool):
 
 			name  = entry["name"].strip()
 			_from = tuple(iteratePaths(entry["from"]))
-			_type = entry["type"].strip().lower()
+
+			if isinstance(entry["type"], str):
+				_type = entry["type"].strip().lower()
+			elif isinstance(entry["type"], int):
+				_type = entry["type"]
+			else:
+				raise RuntimeError("entry type must be a string or an integer")
 
 			# Add the asset to the bundle, preprocessing it if it's a background,
 			# texture or sound or importing it as-is in other cases.

--- a/psxfudge/util.py
+++ b/psxfudge/util.py
@@ -66,6 +66,12 @@ def alignMutableToMultiple(obj, length, padding = b"\x00"):
 	if remaining < length:
 		obj.extend(padding * remaining)
 
+def closestHigherMultiple(x, length):
+	"""
+	Returns the first multipe of `length` higher than `x`
+	"""
+	return math.ceil(x /  length) * length
+
 def hash32(obj):
 	"""
 	Returns the 32-bit "sdbm hash" of a string, byte array or other iterable.


### PR DESCRIPTION
I fixed the entry type parser to allow only strings and integers. Integers weren't accepted before due to a bug.
I also changed the header section to include the sector-aligned section lengths rather than the unpadded ones to make parsing on the PSX faster.