### PR TITLE
Fixed pyav AudioResampler layout argument

### DIFF
--- a/psxfudge/audio.py
+++ b/psxfudge/audio.py
@@ -70,7 +70,7 @@ class SoundWrapper:
 ## Audio file importer
 
 def _importAudio(avFile, channels, sampleRate, chunkLength = 0):
-	resampler = av.AudioResampler("s16p", channels, sampleRate)
+	resampler = av.AudioResampler("s16p", "stereo" if channels == 2 else "mono", sampleRate)
 	fifo      = av.AudioFifo()
 
 	with avFile:


### PR DESCRIPTION
The AudioResampler got changed so it can't just take a number of channels now. It requires either an AudioLayout object or a string. This is a quick fix so I can tell my viewers to use this code without them flooding the issues tab.